### PR TITLE
Dockerfile added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+deploy:
+  provider: script
+  script: bash docker_push
+  on:
+    branch: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.8
+RUN wget https://github.com/ironman-project/ironman/releases/download/v0.3.0/ironman.linux-amd64.tar.gz \
+&& tar -xzvf ironman.linux-amd64.tar.gz -C /usr/local/bin/ \
+&& ironman version

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+docker push omarvides/docker-ironman-spec


### PR DESCRIPTION
Dockerfile currently installs ironman and shows the current version of ironman installed on build time.

This means steps like 
* `ironman install https://github.com/omarvides/express-api-with-mongo-template.git`
* `ironman generate express-api:api /directory/to/create/your-api`

Can be run at CI/CD servers like Drone.io, Travis-ci or Circleci

For start this should be enough to catch exit status different than `0` when running a generator.

This resolves #1 